### PR TITLE
Feature/entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![NPM downloads][npm-downloads-image]][npm-url]
 [![MIT License][license-image]][license-url]
 
-Simple functional script to loop array, strings, numbers, objects, Map and Set
+Simple functional script to loop array, strings, numbers, objects, Map and Set.
+
+Always returns an Array of `[value, key]`.
 
 # Installation
 
@@ -23,14 +25,14 @@ const nullCollection = looppa(null) // []
 const undefinedCollection = looppa(undefined) // []
 
 // arrays will be left untouched
-const array = looppa(['foo', null, undefined]); // ['foo', null, undefined]
+const array = looppa(['foo', null, undefined]); // [['foo', 0], [null, 1], [undefined, 2]]
 
 // numbers to array
-const numbers = looppa(4); // [1, 2, 3, 4]
-const square = numbers.map(n => n * 2); // [2, 4, 6, 8]
+const numbers = looppa(0, 4); // [[0, 0], [1, 1], [2, 2], [3, 3], [4, 4]]
+const square = numbers.map(([n]) => n * 2); // [2, 4, 6, 8]
 
 // strings to array
-const string = looppa('ciao'); // ['c', 'i', 'a', 'o']
+const string = looppa('ciao'); // [['c', 0], ['i', 1], ['a', 2], ['o', 3]]
 
 // objects to array
 const obj = looppa({ foo: 'bar', buz: 'baz' }); // [['foo', 'bar'], ['buz', 'baz']]
@@ -45,7 +47,7 @@ const map = looppa(myMap) // [['foo', 'bar'], ['buz', 'baz']]
 const mySet = new Set();
 mySet.add('foo');
 mySet.add('bar');
-const map = looppa(mySet); // ['foo' 'bar']
+const map = looppa(mySet); // [['foo', 'foo'], ['bar', 'bar']]
 ```
 
 # With React.js
@@ -57,49 +59,49 @@ This script is really handy if you need to deal with React loops
 
   <h1>Array</h1>
   <ul>
-    {looppa([1, 2, 3]).map(number => (
+    {looppa([1, 2, 3]).map(([number]) => (
       <li>{number}</li>
     ))}
   </ul>
 
   <h1>Numbers</h1>
   <ul>
-    {looppa(5).map(number => (
+    {looppa(0, 5).map(([number]) => (
       <li>{number}</li>
     ))}
   </ul>
 
   <h1>Letters</h1>
   <ul>
-    {looppa('ciao').map(letter => (
+    {looppa('ciao').map(([letter]) => (
       <li>{letter}</li>
     ))}
   </ul>
 
   <h1>Object</h1>
   <ul>
-    {looppa({ foo: 'bar', baz: 'buz' }).map(([key, value]) => (
+    {looppa({ foo: 'bar', baz: 'buz' }).map(([value, key]) => (
       <li>{key}, {value}</li>
     ))}
   </ul>
 
   <h1>Map</h1>
   <ul>
-    {looppa(new Map().set(NaN, 'bar')).map(([key, value]) => (
+    {looppa(new Map().set({}, 'bar')).map(([value, key]) => (
       <li>{key}, {value}</li>
     ))}
   </ul>
 
   <h1>Set</h1>
   <ul>
-    {looppa(new Set().add('foo').add('bar')).map(value => (
+    {looppa(new Set().add('foo').add('bar')).map(([value]) => (
       <li>{value}</li>
     ))}
   </ul>
 </div>
 ```
 
-[check the demo](https://plnkr.co/edit/uobOWoWS8EpG9kgtwpwL?p=preview)
+[check the demo](https://plnkr.co/edit/rayViTEz4XPv6DnBP3ZN?p=preview)
 
 
 [travis-image]:https://img.shields.io/travis/dreipol/looppa.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This script is really handy if you need to deal with React loops
 
   <h1>Map</h1>
   <ul>
-    {looppa(new Map().set({}, 'bar')).map(([value, key]) => (
+    {looppa(new Map().set(1, 'bar')).map(([value, key]) => (
       <li>{key}, {value}</li>
     ))}
   </ul>

--- a/index.next.js
+++ b/index.next.js
@@ -1,9 +1,17 @@
 /**
  * Try to make loopable any kind of javascript primitive
- * @param   {array|number|string|object|Map|Set} collection - hopefully something that we can loop
+ * @param   {any} collection - hopefully something that we can loop
+ * @param   {number} to - the end of a number range
  * @returns {Array} it will return always an array
  */
-export default function looppa(collection) {
+export default function looppa(collection, to) {
+    // Special case: handle numbers
+    if (isNumber(collection) && isNumber(to)) {
+        return Array.from({ length: (to - collection + 1) }, (v, key) => [collection + key, collection + key]);
+    } else if (to) {
+        throw new TypeError('Both arguments need to be a number when creating a number range.');
+    }
+
     // handle falsy values
     if (!collection) {
         return [];
@@ -12,18 +20,23 @@ export default function looppa(collection) {
     // handle objects with an 'entries' function
     // such as: Arrays, Maps, Sets, NodeLists...
     if (typeof collection.entries === 'function') {
-        return [...collection.entries()];
-    }
-
-    // handle numbers
-    if (typeof collection === 'number') {
-        return Array.from({ length: collection }, (v, key) => [key, key]);
+        return [...collection.entries()].map(entry => entry.reverse());
     }
 
     // Default for all other object types, strings, booleans and symbols
     return Object
         .keys(collection)
         .map((key) => {
-            return [key, collection[key]];
+            return [collection[key], key];
         });
+}
+
+/**
+ * Helper function to determine if number is a Number
+ *
+ * @param  {number}  number - the value to check
+ * @return {Boolean} is it a number?
+ */
+function isNumber(number) {
+    return typeof number === 'number' && !isNaN(number);
 }

--- a/index.next.js
+++ b/index.next.js
@@ -15,18 +15,15 @@ export default function looppa(collection) {
         return [...collection.entries()];
     }
 
-    // handle numbers and strings
-    switch (typeof collection) {
-        case 'number':
-            return Array.from({ length: collection }, (v, key) => key);
-        case 'string':
-            return collection.split('');
-        default:
-            // Default for all other object types, booleans and symbols
-            return Object
-                .keys(collection)
-                .map((key) => {
-                    return [key, collection[key]];
-                });
+    // handle numbers
+    if (typeof collection === 'number') {
+        return Array.from({ length: collection }, (v, key) => [key, key]);
     }
+
+    // Default for all other object types, strings, booleans and symbols
+    return Object
+        .keys(collection)
+        .map((key) => {
+            return [key, collection[key]];
+        });
 }

--- a/index.next.js
+++ b/index.next.js
@@ -9,31 +9,24 @@ export default function looppa(collection) {
         return [];
     }
 
-    // don't touch arrays
-    if (Array.isArray(collection)) {
-        return collection;
+    // handle objects with an 'entries' function
+    // such as: Arrays, Maps, Sets, NodeLists...
+    if (typeof collection.entries === 'function') {
+        return [...collection.entries()];
     }
 
     // handle numbers and strings
     switch (typeof collection) {
         case 'number':
-            return Object.keys(Array.from(Array(collection)));
+            return Array.from({ length: collection }, (v, key) => key);
         case 'string':
             return collection.split('');
         default:
-            //noop
+            // Default for all other object types, booleans and symbols
+            return Object
+                .keys(collection)
+                .map((key) => {
+                    return [key, collection[key]];
+                });
     }
-
-    // get the object entries
-    if (Object.prototype.toString.call(collection) === '[object Object]') {
-        return Object
-            .keys(collection)
-            .reduce(function(acc, key) {
-                acc.push([key, collection[key]]);
-                return acc;
-            }, []);
-    }
-
-    // loop Map and Set
-    return Array.from(collection);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looppa",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Simple functional script to loop array, strings, numbers, objects, Map and Set",
   "main": "index.js",
   "module": "index.next.js",

--- a/test.js
+++ b/test.js
@@ -15,35 +15,46 @@ describe('looppa the looper', () => {
         const iter = looppa([1, 2, 3]);
         assert.ok(iter.map);
         assert.equal(iter.length, 3);
-        assert.deepEqual(iter, [[0, 1], [1, 2], [2, 3]]);
+        assert.deepEqual(iter, [[1, 0], [2, 1], [3, 2]]);
     });
 
     it('convert numbers into arrays', () => {
-        const iter = looppa(3);
+        const iter = looppa(0, 3);
         assert.ok(iter.map);
-        assert.equal(iter.length, 3);
-        assert.deepEqual(iter, [[0, 0], [1, 1], [2, 2]]);
+        assert.equal(iter.length, 4);
+        assert.deepEqual(iter, [[0, 0], [1, 1], [2, 2], [3, 3]]);
+    });
+
+    it('convert a range of numbers into arrays', () => {
+        const iter = looppa(0, 3);
+        assert.ok(iter.map);
+        assert.equal(iter.length, 4);
+        assert.deepEqual(iter, [[0, 0], [1, 1], [2, 2], [3, 3]]);
+    });
+
+    it('throw TypeError if second argument is not a number', () => {
+        assert.throws(looppa.bind(null, 0, 'a'), TypeError);
     });
 
     it('convert strings into arrays', () => {
         const iter = looppa('ciao');
         assert.ok(iter.map);
         assert.equal(iter.length, 4);
-        assert.deepEqual(iter, [[0, 'c'], [1, 'i'], [2, 'a'], [3, 'o']]);
+        assert.deepEqual(iter, [['c', 0], ['i', 1], ['a', 2], ['o', 3]]);
     });
 
     it('convert objects into arrays', () => {
         const iter = looppa({ foo: 'bar', baz: 'buz' });
         assert.ok(iter.map);
         assert.equal(iter.length, 2);
-        assert.deepEqual(iter, [['foo', 'bar'], ['baz', 'buz']]);
+        assert.deepEqual(iter, [['bar', 'foo'], ['buz', 'baz']]);
     });
 
     it('convert Maps into arrays', () => {
         const iter = looppa(new Map().set({}, 'foo'));
         assert.ok(iter.map);
         assert.equal(iter.length, 1);
-        assert.deepEqual(iter, [[{}, 'foo']]);
+        assert.deepEqual(iter, [['foo', {}]]);
     });
 
     it('convert Sets into arrays', () => {

--- a/test.js
+++ b/test.js
@@ -11,34 +11,39 @@ describe('looppa the looper', () => {
         assert.equal(undefinedIter.length, 0);
     });
 
-    it('leave untouched row arrays', () => {
+    it('convert arrays into array entries', () => {
         const iter = looppa([1, 2, 3]);
         assert.ok(iter.map);
         assert.equal(iter.length, 3);
+        assert.deepEqual(iter, [[0, 1], [1, 2], [2, 3]]);
     });
 
     it('convert numbers into arrays', () => {
         const iter = looppa(3);
         assert.ok(iter.map);
         assert.equal(iter.length, 3);
+        assert.deepEqual(iter, [0, 1, 2]);
     });
 
     it('convert strings into arrays', () => {
         const iter = looppa('ciao');
         assert.ok(iter.map);
         assert.equal(iter.length, 4);
+        assert.deepEqual(iter, ['c', 'i', 'a', 'o']);
     });
 
     it('convert objects into arrays', () => {
         const iter = looppa({ foo: 'bar', baz: 'buz' });
         assert.ok(iter.map);
         assert.equal(iter.length, 2);
+        assert.deepEqual(iter, [['foo', 'bar'], ['baz', 'buz']]);
     });
 
     it('convert Maps into arrays', () => {
-        const iter = looppa(new Map().set(NaN, 'foo'));
+        const iter = looppa(new Map().set({}, 'foo'));
         assert.ok(iter.map);
         assert.equal(iter.length, 1);
+        assert.deepEqual(iter, [[{}, 'foo']]);
     });
 
     it('convert Sets into arrays', () => {
@@ -48,5 +53,6 @@ describe('looppa the looper', () => {
         const iter = looppa(set);
         assert.ok(iter.map);
         assert.equal(iter.length, 2);
+        assert.deepEqual(iter, [['foo', 'foo'], ['bar', 'bar']]);
     });
 });

--- a/test.js
+++ b/test.js
@@ -22,14 +22,14 @@ describe('looppa the looper', () => {
         const iter = looppa(3);
         assert.ok(iter.map);
         assert.equal(iter.length, 3);
-        assert.deepEqual(iter, [0, 1, 2]);
+        assert.deepEqual(iter, [[0, 0], [1, 1], [2, 2]]);
     });
 
     it('convert strings into arrays', () => {
         const iter = looppa('ciao');
         assert.ok(iter.map);
         assert.equal(iter.length, 4);
-        assert.deepEqual(iter, ['c', 'i', 'a', 'o']);
+        assert.deepEqual(iter, [[0, 'c'], [1, 'i'], [2, 'a'], [3, 'o']]);
     });
 
     it('convert objects into arrays', () => {


### PR DESCRIPTION
I normalized the output arrays for all objects and primitives into the following format:
```js
[['value', 'key'], ['value', 'key']]
```
Sets are a special case, as they have no `key`. Instead, according to spec, we return:
```js
[['value', 'value'], ['value', 'value']]
```

Number values now return an Array of Numbers instead of Strings.

The tests now do a deepEqual to check if the Array format is correct as well.